### PR TITLE
fix 'Compile As' name input field

### DIFF
--- a/src/ResourceManagers/AssetsManager.cpp
+++ b/src/ResourceManagers/AssetsManager.cpp
@@ -1059,7 +1059,7 @@ bool AssetsManager::isCompilable(bool needPath) {
 
 void AssetsManager::doPopupAssetsCompileAs() {
     ImGui::Text("Name:");
-    ImGui::InputText("##Name", &m_assetsInfo.name, m_assetsInfo.name.size());
+    ImGui::InputText("##Name", m_assetsInfo.name, sizeof(m_assetsInfo.name));
 
     ImGui::Spacing();
 

--- a/src/ResourceManagers/AssetsManager.h
+++ b/src/ResourceManagers/AssetsManager.h
@@ -32,7 +32,7 @@ struct AssetsInfo {
     bool frameGroups = false;
 
     // Compiling stuff
-    std::string name = "Tibia"; // assets name without extension
+    char name[128] = "Tibia"; // assets name without extension
     int compileTypeIndex = 1;
     std::string outputPath;
 };


### PR DESCRIPTION
It couldn't be edited, cause it was a std::string. Now I've changed it to a char buffer.

Fixes #4 